### PR TITLE
Fix env var issues

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -2,5 +2,7 @@ TURNKEY_API_PUBLIC_KEY="<Turnkey API Public Key (that starts with 02 or 03)>"
 TURNKEY_API_PRIVATE_KEY="<Turnkey API Private Key>"
 NEXT_PUBLIC_ORGANIZATION_ID="<Turnkey organization ID>"
 NEXT_PUBLIC_TURNKEY_API_BASE_URL=https://api.turnkey.com
-NEXT_PUBLIC_RPID=localhost # replace with domain in production
-NEXT_PUBLIC_SERVER_SIGN_URL=http://localhost:3000/api # replace with backend URL in production
+# replace with domain in production
+NEXT_PUBLIC_RPID=localhost
+# replace with backend URL in production
+NEXT_PUBLIC_SERVER_SIGN_URL=http://localhost:3000/api

--- a/src/pages/api/createSubOrg.ts
+++ b/src/pages/api/createSubOrg.ts
@@ -1,7 +1,7 @@
-import type { NextApiRequest, NextApiResponse } from 'next';
-import { Turnkey, TurnkeyApiTypes } from '@turnkey/sdk-server';
-import { refineNonNull } from '@/utils';
-import { TWalletDetails } from '@/types';
+import type { NextApiRequest, NextApiResponse } from "next";
+import { Turnkey, TurnkeyApiTypes } from "@turnkey/sdk-server";
+import { refineNonNull } from "@/utils";
+import { TWalletDetails } from "@/types";
 
 // Default path for the first Ethereum address in a new HD wallet.
 // See https://github.com/bitcoin/bips/blob/master/bip-0044.mediawiki, paths are in the form:
@@ -9,9 +9,9 @@ import { TWalletDetails } from '@/types';
 // - Purpose is a constant set to 44' following the BIP43 recommendation.
 // - Coin type is set to 60 (ETH) -- see https://github.com/satoshilabs/slips/blob/master/slip-0044.md
 // - Account, Change, and Address Index are set to 0
-import { DEFAULT_ETHEREUM_ACCOUNTS } from '@turnkey/sdk-server';
+import { DEFAULT_ETHEREUM_ACCOUNTS } from "@turnkey/sdk-server";
 
-type TAttestation = TurnkeyApiTypes['v1Attestation'];
+type TAttestation = TurnkeyApiTypes["v1Attestation"];
 
 type CreateSubOrgWithWalletRequest = {
   subOrgName: string;
@@ -46,11 +46,11 @@ export default async function createUser(
       rootQuorumThreshold: 1,
       rootUsers: [
         {
-          userName: 'New user',
+          userName: "New user",
           apiKeys: [],
           authenticators: [
             {
-              authenticatorName: 'Passkey',
+              authenticatorName: "Passkey",
               challenge: createSubOrgRequest.challenge,
               attestation: createSubOrgRequest.attestation,
             },
@@ -78,7 +78,7 @@ export default async function createUser(
     console.error(e);
 
     res.status(500).json({
-      message: 'Something went wrong.',
+      message: "Something went wrong.",
     });
   }
 }

--- a/src/pages/api/createSubOrg.ts
+++ b/src/pages/api/createSubOrg.ts
@@ -1,7 +1,7 @@
-import type { NextApiRequest, NextApiResponse } from "next";
-import { Turnkey, TurnkeyApiTypes } from "@turnkey/sdk-server";
-import { refineNonNull } from "@/utils";
-import { TWalletDetails } from "@/types";
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { Turnkey, TurnkeyApiTypes } from '@turnkey/sdk-server';
+import { refineNonNull } from '@/utils';
+import { TWalletDetails } from '@/types';
 
 // Default path for the first Ethereum address in a new HD wallet.
 // See https://github.com/bitcoin/bips/blob/master/bip-0044.mediawiki, paths are in the form:
@@ -9,9 +9,9 @@ import { TWalletDetails } from "@/types";
 // - Purpose is a constant set to 44' following the BIP43 recommendation.
 // - Coin type is set to 60 (ETH) -- see https://github.com/satoshilabs/slips/blob/master/slip-0044.md
 // - Account, Change, and Address Index are set to 0
-import { DEFAULT_ETHEREUM_ACCOUNTS } from "@turnkey/sdk-server";
+import { DEFAULT_ETHEREUM_ACCOUNTS } from '@turnkey/sdk-server';
 
-type TAttestation = TurnkeyApiTypes["v1Attestation"];
+type TAttestation = TurnkeyApiTypes['v1Attestation'];
 
 type CreateSubOrgWithWalletRequest = {
   subOrgName: string;
@@ -31,9 +31,9 @@ export default async function createUser(
 
   try {
     const turnkey = new Turnkey({
-      apiBaseUrl: process.env.NEXT_PUBLIC_BASE_URL!,
-      apiPrivateKey: process.env.API_PRIVATE_KEY!,
-      apiPublicKey: process.env.API_PUBLIC_KEY!,
+      apiBaseUrl: process.env.NEXT_PUBLIC_TURNKEY_API_BASE_URL!,
+      apiPrivateKey: process.env.TURNKEY_API_PRIVATE_KEY!,
+      apiPublicKey: process.env.TURNKEY_API_PUBLIC_KEY!,
       defaultOrganizationId: process.env.NEXT_PUBLIC_ORGANIZATION_ID!,
     });
 
@@ -46,11 +46,11 @@ export default async function createUser(
       rootQuorumThreshold: 1,
       rootUsers: [
         {
-          userName: "New user",
+          userName: 'New user',
           apiKeys: [],
           authenticators: [
             {
-              authenticatorName: "Passkey",
+              authenticatorName: 'Passkey',
               challenge: createSubOrgRequest.challenge,
               attestation: createSubOrgRequest.attestation,
             },
@@ -78,7 +78,7 @@ export default async function createUser(
     console.error(e);
 
     res.status(500).json({
-      message: "Something went wrong.",
+      message: 'Something went wrong.',
     });
   }
 }


### PR DESCRIPTION
* Fixes #9

  Moves EOL comments in the `.env.local.example` to the line above as it was causing them to be included in the parsed env var value as shown below:
    ```
    {
        "defaultOrganizationId": "70189536-9086-4810-a9f0-990d4e7cd622",
        "rpId": "localhost # replace with domain in production",
        "serverSignUrl": "http://localhost:3000/api # replace with backend URL in production",
        "iframeUrl": "https://auth.turnkey.com"
    }
    ```

* Fixes #8 -  Renames env vars used in the Turnkey server client config (credit: @jpdreamos 🙏)